### PR TITLE
Fix cm_api installation on impala recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,8 @@
 #
 include_attribute "java"
 
+node.set['python']['setuptools_version']="8.2"
+
 default['base']['hosts'] = {
   '127.0.0.1' => ['localhost', 'localhost.localdomain', 'localhost4', 'localhost4.localdomain4'],
   '::1'       => ['localhost', 'localhost.localdomain', 'localhost6', 'localhost6.localdomain6']

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "abutovich@qubell.com"
 license          "All rights reserved"
 description      "Provision Cloudera Hadoop"
 name		 "cloudera"
-version          "2.0.0"
+version          "2.1.0"
 
 depends "yum", '~> 3.3.1'
 depends "ntp", '~> 1.6.4'

--- a/recipes/impala_start.rb
+++ b/recipes/impala_start.rb
@@ -1,5 +1,5 @@
 include_recipe "python::pip"
-execute "pip install --upgrade setuptools"
+
 python_pip "cm_api" do
   version "6.0.2"
   retries 2


### PR DESCRIPTION
- Removed setuptools update from impala_start recipe
- Set setuptools_version to fixed version
- Hadoop cookbook metadata set to 2.1.0

Please, set tag 2.1.0
